### PR TITLE
Remove Dependency on `manipulation`

### DIFF
--- a/examples/tutorial1/tutorial.py
+++ b/examples/tutorial1/tutorial.py
@@ -15,7 +15,8 @@ from pydrake.all import (
     DrakeVisualizer, Meshcat, MeshcatVisualizer, Simulator,
 )
 
-from manipulation.scenarios import AddMultibodyTriad
+# Internal imports
+from brom_drake.utils import AddMultibodyTriad
 
 def AddGround(plant):
     """

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
         long_description=long_description,
         # packages=find_packages(where='src/brom_drake'),
         install_requires=[
-            'drake', 'meshcat', 'manipulation',
+            'drake', 'meshcat',
             'loguru', 'matplotlib', 'numpy',
             'pycollada', 'trimesh',
         ],

--- a/src/brom_drake/example_helpers/block_handler_system.py
+++ b/src/brom_drake/example_helpers/block_handler_system.py
@@ -6,13 +6,11 @@ from pydrake.multibody.parsing import Parser
 from pydrake.multibody.plant import MultibodyPlant, CoulombFriction
 from pydrake.systems.framework import Diagram, DiagramBuilder, LeafSystem, PortDataType, BasicVector
 
-from manipulation.scenarios import AddMultibodyTriad
-
 import numpy as np
 
 # Internal Imports
 from brom_drake import example_helpers as eh
-from brom_drake.utils import AddGround
+from brom_drake.utils import AddGround, AddMultibodyTriad
 
 class BlockHandlerSystem(LeafSystem):
     def __init__(

--- a/src/brom_drake/productions/debug/grasping/demonstrate_static_grasp.py
+++ b/src/brom_drake/productions/debug/grasping/demonstrate_static_grasp.py
@@ -1,7 +1,6 @@
 from typing import List, Tuple, Union
 
 import numpy as np
-from manipulation.scenarios import AddMultibodyTriad
 from pydrake.all import (
     RigidBodyFrame,
     RigidTransform
@@ -19,7 +18,7 @@ from brom_drake.robots import find_base_link_name_in
 from brom_drake.productions.types import BaseProduction
 from brom_drake.productions import ProductionID
 from brom_drake.productions.roles.role import Role
-from brom_drake.utils import Performer
+from brom_drake.utils import Performer, AddMultibodyTriad
 from brom_drake.productions.debug.show_me.show_me_system import ShowMeSystem
 
 class DemonstrateStaticGrasp(BaseProduction):

--- a/src/brom_drake/productions/debug/show_me/show_me_system.py
+++ b/src/brom_drake/productions/debug/show_me/show_me_system.py
@@ -1,9 +1,9 @@
-from manipulation.scenarios import AddMultibodyTriad
 import numpy as np
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.tree import ModelInstanceIndex
 from pydrake.systems.framework import LeafSystem, BasicVector
 
+from brom_drake.utils import AddMultibodyTriad
 
 class ShowMeSystem(LeafSystem):
     """

--- a/src/brom_drake/productions/debug/show_me/show_me_this_model.py
+++ b/src/brom_drake/productions/debug/show_me/show_me_this_model.py
@@ -1,7 +1,6 @@
 from typing import List, Tuple
 
 import numpy as np
-from manipulation.scenarios import AddMultibodyTriad
 from pydrake.geometry import Meshcat, MeshcatVisualizer, MeshcatVisualizerParams
 from pydrake.geometry import Role as DrakeRole
 from pydrake.multibody.parsing import Parser
@@ -15,7 +14,7 @@ from brom_drake.robots import find_base_link_name_in
 from brom_drake.productions.types import BaseProduction
 from brom_drake.productions import ProductionID
 from brom_drake.productions.roles.role import Role
-from brom_drake.utils import Performer
+from brom_drake.utils import Performer, AddMultibodyTriad
 from .show_me_system import ShowMeSystem
 
 class ShowMeThisModel(BaseProduction):

--- a/src/brom_drake/utils/__init__.py
+++ b/src/brom_drake/utils/__init__.py
@@ -7,8 +7,11 @@ from .leaf_systems.end_effector_wrench_calculator import EndEffectorWrenchCalcul
 from .leaf_systems.rigid_transform_to_vector_system import RigidTransformToVectorSystem
 from .constants import Performer, MotionPlan
 from .ground import AddGround, GroundShape
+from .triads import AddMultibodyTriad, AddTriad
 
 __all__ = [
+    "AddMultibodyTriad",
+    "AddTriad",
     "BoolToVectorSystem",
     "EndEffectorWrenchCalculator",
     "find_all_systems_with_input_port",

--- a/src/brom_drake/utils/triads.py
+++ b/src/brom_drake/utils/triads.py
@@ -1,0 +1,76 @@
+from pydrake.all import (
+    Cylinder,
+    GeometryInstance,
+    MakePhongIllustrationProperties,
+    RigidTransform,
+    RotationMatrix,
+)
+
+def AddTriad(
+    source_id,
+    frame_id,
+    scene_graph,
+    length=0.25,
+    radius=0.01,
+    opacity=1.0,
+    X_FT=RigidTransform(),
+    name="frame",
+):
+    """
+    Adds illustration geometry representing the coordinate frame, with the
+    x-axis drawn in red, the y-axis in green and the z-axis in blue. The axes
+    point in +x, +y and +z directions, respectively.
+
+    Args:
+      source_id: The source registered with SceneGraph.
+      frame_id: A geometry::frame_id registered with scene_graph.
+      scene_graph: The SceneGraph with which we will register the geometry.
+      length: the length of each axis in meters.
+      radius: the radius of each axis in meters.
+      opacity: the opacity of the coordinate axes, between 0 and 1.
+      X_FT: a RigidTransform from the triad frame T to the frame_id frame F
+      name: the added geometry will have names name + " x-axis", etc.
+    """
+    # x-axis
+    X_TG = RigidTransform(RotationMatrix.MakeYRotation(np.pi / 2), [length / 2.0, 0, 0])
+    geom = GeometryInstance(
+        X_FT.multiply(X_TG), Cylinder(radius, length), name + " x-axis"
+    )
+    geom.set_illustration_properties(
+        MakePhongIllustrationProperties([1, 0, 0, opacity])
+    )
+    scene_graph.RegisterGeometry(source_id, frame_id, geom)
+
+    # y-axis
+    X_TG = RigidTransform(RotationMatrix.MakeXRotation(np.pi / 2), [0, length / 2.0, 0])
+    geom = GeometryInstance(
+        X_FT.multiply(X_TG), Cylinder(radius, length), name + " y-axis"
+    )
+    geom.set_illustration_properties(
+        MakePhongIllustrationProperties([0, 1, 0, opacity])
+    )
+    scene_graph.RegisterGeometry(source_id, frame_id, geom)
+
+    # z-axis
+    X_TG = RigidTransform([0, 0, length / 2.0])
+    geom = GeometryInstance(
+        X_FT.multiply(X_TG), Cylinder(radius, length), name + " z-axis"
+    )
+    geom.set_illustration_properties(
+        MakePhongIllustrationProperties([0, 0, 1, opacity])
+    )
+    scene_graph.RegisterGeometry(source_id, frame_id, geom)
+
+
+def AddMultibodyTriad(frame, scene_graph, length=0.25, radius=0.01, opacity=1.0):
+    plant = frame.GetParentPlant()
+    AddTriad(
+        plant.get_source_id(),
+        plant.GetBodyFrameIdOrThrow(frame.body().index()),
+        scene_graph,
+        length,
+        radius,
+        opacity,
+        frame.GetFixedPoseInBodyFrame(),
+        name=frame.name(),
+    )

--- a/src/brom_drake/utils/triads.py
+++ b/src/brom_drake/utils/triads.py
@@ -1,20 +1,23 @@
+import numpy as np
 from pydrake.all import (
     Cylinder,
+    Frame,
     GeometryInstance,
     MakePhongIllustrationProperties,
     RigidTransform,
     RotationMatrix,
+    SceneGraph,
 )
 
 def AddTriad(
     source_id,
     frame_id,
-    scene_graph,
-    length=0.25,
-    radius=0.01,
-    opacity=1.0,
-    X_FT=RigidTransform(),
-    name="frame",
+    scene_graph: SceneGraph,
+    length: float = 0.25,
+    radius: float = 0.01,
+    opacity: float = 1.0,
+    X_FT: RigidTransform = RigidTransform(),
+    name: str= "frame",
 ):
     """
     Adds illustration geometry representing the coordinate frame, with the
@@ -62,7 +65,7 @@ def AddTriad(
     scene_graph.RegisterGeometry(source_id, frame_id, geom)
 
 
-def AddMultibodyTriad(frame, scene_graph, length=0.25, radius=0.01, opacity=1.0):
+def AddMultibodyTriad(frame: Frame, scene_graph: SceneGraph, length: float =0.25, radius: float =0.01, opacity: float =1.0):
     plant = frame.GetParentPlant()
     AddTriad(
         plant.get_source_id(),


### PR DESCRIPTION
It appears that our reliance on the `manipulation` library from RobotLocomotion might have been messing with how others experience the package (it required very weird versions of popular libraries). Since we only use that library for one function, let's replace its usage in `brom_drake` with our own implementation and cut free of `manipulation`.