### PR TITLE
Address Some Mesh File Path Handling Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ To learn more, look through our documentation [here](https://kwesirutledge.githu
 pip install brom-drake
 ```
 
+### ROS 2-capable install
+
+If you use ROS 2 package URIs (for example, `package://...`) and want
+`brom_drake` to resolve package share directories via `ament_index_python`,
+install the optional ROS 2 extra:
+
+```shell
+pip install "brom-drake[ros2]"
+```
+
+In most ROS 2 workflows, make sure your ROS 2 environment is sourced before
+running your scripts so package discovery works as expected.
+
 ### Developer install
 
 You can also install the package during local development by cloning

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ if __name__ == "__main__":
                 "pytest-cov",
             ],
             "dev": ["ipdb", "typer", "black"],
+            "ros2": ["ament-index-python"],
         },
         keywords=["drake", "robotics", "testing", "logging"],
         classifiers=[

--- a/src/brom_drake/file_manipulation/urdf/drake_ready_urdf_converter/mesh_file_converter.py
+++ b/src/brom_drake/file_manipulation/urdf/drake_ready_urdf_converter/mesh_file_converter.py
@@ -8,6 +8,7 @@ import trimesh
 
 try:
     from ament_index_python.packages import get_package_share_directory
+
     _AMENT_INDEX_AVAILABLE = True
 except ImportError:
     _AMENT_INDEX_AVAILABLE = False

--- a/src/brom_drake/file_manipulation/urdf/drake_ready_urdf_converter/mesh_file_converter.py
+++ b/src/brom_drake/file_manipulation/urdf/drake_ready_urdf_converter/mesh_file_converter.py
@@ -6,6 +6,12 @@ import xml.etree.ElementTree as ET
 
 import trimesh
 
+try:
+    from ament_index_python.packages import get_package_share_directory
+    _AMENT_INDEX_AVAILABLE = True
+except ImportError:
+    _AMENT_INDEX_AVAILABLE = False
+
 # Internal imports
 from brom_drake.file_manipulation.urdf.drake_ready_urdf_converter.util import (
     URDF_CONVERSION_LOG_LEVEL_NAME,
@@ -192,17 +198,23 @@ class MeshFileConverter:
         self,
         max_depth: int = 10,
     ) -> Tuple[Path, str]:
-        # Setup
+        # If ament_index_python is available (ROS 2 environment), use it directly.
+        if _AMENT_INDEX_AVAILABLE:
+            # Extract the package name from "package://pkg_name/..."
+            package_name = self.mesh_file.split("/")[2]
+            package_dir = Path(get_package_share_directory(package_name))
+            self.logger.info(
+                f"[MeshFileConverter] Resolved package '{package_name}' via ament index at {package_dir}."
+            )
+            return package_dir, package_name
+
+        # Fallback: walk up the directory tree looking for package.xml.
         original_urdf_dir = Path(self.urdf_dir)
 
-        # Find the path to the package
         package_found = False
         candidate_path = original_urdf_dir
         search_depth = 1
         while not package_found:
-            # print(f"candidate_path: {candidate_path}")
-
-            # Check to see if "package.xml" exists in the directory
             if (candidate_path / "package.xml").exists():
                 self.logger.info(
                     f"[MeshFileConverter] Found package path at {candidate_path}."
@@ -235,24 +247,17 @@ class MeshFileConverter:
         # Algorithm
         mesh_file = self.mesh_file
 
-        # Check to see if file path starts with "./"
-        if mesh_file.startswith("./"):
-            return True
-
         # Ignore this if the mesh file contains a package prefix
         if mesh_file.startswith("package:"):
             return False
 
-        # Check to see if the first part of the path contains a folder or file
-        # in the current directory
+        # Handle file:// URIs by checking whether the URI payload is absolute.
         if mesh_file.startswith("file://"):
             mesh_file = mesh_file.replace("file://", "")
             return not os.path.isabs(mesh_file)
 
-        # Now, check to see if the target file exists
-        complete_file_path = self.urdf_dir / Path(mesh_file)
-        exists = complete_file_path.exists()
-        return exists
+        # Treat any non-package, non-absolute path (including ../...) as relative.
+        return not os.path.isabs(mesh_file)
 
         # raise FileNotFoundError(
         #     f"File {complete_file_path} does not exist in directory {os.getcwd()}!"

--- a/tests/file_manipulation/urdf/DrakeReadyURDFConverter/mesh_file_converter_test.py
+++ b/tests/file_manipulation/urdf/DrakeReadyURDFConverter/mesh_file_converter_test.py
@@ -23,12 +23,12 @@ from brom_drake.file_manipulation.urdf.drake_ready_urdf_converter.mesh_file_conv
 )
 
 # Module path used for patching
-_MODULE = "brom_drake.file_manipulation.urdf.drake_ready_urdf_converter.mesh_file_converter"
+_MODULE = (
+    "brom_drake.file_manipulation.urdf.drake_ready_urdf_converter.mesh_file_converter"
+)
 
 # Shared test data
-_TEST_PACKAGE_DIR = Path(
-    str(impresources.files(resources_dir) / "test_package")
-)
+_TEST_PACKAGE_DIR = Path(str(impresources.files(resources_dir) / "test_package"))
 _PACKAGE_NAME = "baxter_description"
 _MESH_URI = f"package://{_PACKAGE_NAME}/meshes/torso/base_link.DAE"
 _EXPECTED_RELATIVE_MESH_PATH = Path("meshes/torso/base_link.DAE")

--- a/tests/file_manipulation/urdf/DrakeReadyURDFConverter/mesh_file_converter_test.py
+++ b/tests/file_manipulation/urdf/DrakeReadyURDFConverter/mesh_file_converter_test.py
@@ -1,0 +1,184 @@
+"""
+mesh_file_converter_test.py
+Description:
+    Tests for MeshFileConverter, with a focus on resolving mesh files
+    that are referenced via ROS 2 package:// URIs.
+
+    The ROS 2 ament path (Option 3) is tested by mocking
+    _AMENT_INDEX_AVAILABLE and get_package_share_directory so that the
+    tests run without requiring a live ROS 2 installation.
+"""
+
+import logging
+import tempfile
+import unittest
+from importlib import resources as impresources
+from pathlib import Path
+from unittest.mock import patch
+
+import resources as resources_dir
+
+from brom_drake.file_manipulation.urdf.drake_ready_urdf_converter.mesh_file_converter import (
+    MeshFileConverter,
+)
+
+# Module path used for patching
+_MODULE = "brom_drake.file_manipulation.urdf.drake_ready_urdf_converter.mesh_file_converter"
+
+# Shared test data
+_TEST_PACKAGE_DIR = Path(
+    str(impresources.files(resources_dir) / "test_package")
+)
+_PACKAGE_NAME = "baxter_description"
+_MESH_URI = f"package://{_PACKAGE_NAME}/meshes/torso/base_link.DAE"
+_EXPECTED_RELATIVE_MESH_PATH = Path("meshes/torso/base_link.DAE")
+_PARENT_RELATIVE_MESH_PATH = "../meshes/torso/base_link_collision.DAE"
+
+
+def _make_converter(mesh_uri: str, new_urdf_dir: Path) -> MeshFileConverter:
+    return MeshFileConverter(
+        mesh_file_path=mesh_uri,
+        urdf_dir=_TEST_PACKAGE_DIR / "urdf",
+        new_urdf_dir=new_urdf_dir,
+        logger=logging.getLogger("MeshFileConverterTest"),
+    )
+
+
+class MeshFileConverterAmentTest(unittest.TestCase):
+    """
+    Tests for the ament_index_python code path in MeshFileConverter.
+    The ament index is mocked so no ROS 2 installation is required.
+    """
+
+    def _ament_patches(self, package_share_dir: Path):
+        """Return context-manager patches that simulate ament being available."""
+        return (
+            patch(f"{_MODULE}._AMENT_INDEX_AVAILABLE", True),
+            patch(
+                f"{_MODULE}.get_package_share_directory",
+                return_value=str(package_share_dir),
+                create=True,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # find_package_directory_including_mesh
+    # ------------------------------------------------------------------
+
+    def test_find_package_directory_uses_ament_when_available(self):
+        """
+        When _AMENT_INDEX_AVAILABLE is True,
+        find_package_directory_including_mesh should delegate to
+        get_package_share_directory and return the correct
+        (package_dir, package_name) pair.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            converter = _make_converter(_MESH_URI, Path(tmp))
+
+            p1, p2 = self._ament_patches(_TEST_PACKAGE_DIR)
+            with p1, p2:
+                package_dir, package_name = (
+                    converter.find_package_directory_including_mesh()
+                )
+
+        self.assertEqual(package_dir, _TEST_PACKAGE_DIR)
+        self.assertEqual(package_name, _PACKAGE_NAME)
+
+    def test_find_package_directory_passes_correct_package_name_to_ament(self):
+        """
+        get_package_share_directory must be called with exactly the
+        package name extracted from the package:// URI.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            converter = _make_converter(_MESH_URI, Path(tmp))
+
+            p1, p2 = self._ament_patches(_TEST_PACKAGE_DIR)
+            with p1, p2 as mock_get_share:
+                converter.find_package_directory_including_mesh()
+                mock_get_share.assert_called_once_with(_PACKAGE_NAME)
+
+    # ------------------------------------------------------------------
+    # true_mesh_file_path
+    # ------------------------------------------------------------------
+
+    def test_true_mesh_file_path_resolves_via_ament(self):
+        """
+        true_mesh_file_path should return the full path to the mesh file
+        inside the package share directory when ament is available.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            converter = _make_converter(_MESH_URI, Path(tmp))
+
+            p1, p2 = self._ament_patches(_TEST_PACKAGE_DIR)
+            with p1, p2:
+                resolved = converter.true_mesh_file_path()
+
+        expected = _TEST_PACKAGE_DIR / _EXPECTED_RELATIVE_MESH_PATH
+        self.assertEqual(resolved, expected)
+
+    def test_true_mesh_file_path_accepts_parent_relative_path(self):
+        """
+        true_mesh_file_path should accept parent-directory relative paths
+        (e.g., ../meshes/...) and return them as relative paths.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            converter = _make_converter(_PARENT_RELATIVE_MESH_PATH, Path(tmp))
+
+            resolved = converter.true_mesh_file_path()
+
+        self.assertEqual(resolved, Path(_PARENT_RELATIVE_MESH_PATH))
+        self.assertTrue((converter.urdf_dir / resolved).exists())
+
+    # ------------------------------------------------------------------
+    # convert (full pipeline)
+    # ------------------------------------------------------------------
+
+    def test_convert_produces_obj_file_via_ament(self):
+        """
+        The full convert() pipeline should:
+        1. Resolve the mesh through ament.
+        2. Load the DAE file with trimesh.
+        3. Export an .obj to new_urdf_dir.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            new_urdf_dir = Path(tmp)
+            converter = _make_converter(_MESH_URI, new_urdf_dir)
+
+            p1, p2 = self._ament_patches(_TEST_PACKAGE_DIR)
+            with p1, p2:
+                output_path = converter.convert()
+
+            self.assertTrue(
+                output_path.exists(),
+                f"Expected output file at {output_path} but it was not created.",
+            )
+            self.assertEqual(
+                output_path.suffix,
+                ".obj",
+                f"Expected a .obj file, got {output_path.suffix}.",
+            )
+
+    # ------------------------------------------------------------------
+    # Fallback: ament unavailable → upward walk
+    # ------------------------------------------------------------------
+
+    def test_find_package_directory_falls_back_to_walk_when_ament_unavailable(self):
+        """
+        When _AMENT_INDEX_AVAILABLE is False (the default for non-ROS users),
+        find_package_directory_including_mesh should fall back to walking up
+        the directory tree and reading package.xml.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            converter = _make_converter(_MESH_URI, Path(tmp))
+
+            with patch(f"{_MODULE}._AMENT_INDEX_AVAILABLE", False):
+                package_dir, package_name = (
+                    converter.find_package_directory_including_mesh()
+                )
+
+        self.assertEqual(package_dir, _TEST_PACKAGE_DIR)
+        self.assertEqual(package_name, _PACKAGE_NAME)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description

Added small tweaks that allow DrakeifyMyUrdf to be able to handle URDFs with:
- Mesh File Paths that include ROS2 packages (`mesh="package://my_package/something/here.obj")
- Mesh File Paths that start with the relative path symbol ".. (`mesh="../something/cool/here.stl")

# Notes

- Meant to help with some issues in the field.
- To work with ROS2 workspaces, we also now include an optional install of brom_drake that includes the relevant ROS2 requirements. You should install ROS2 before installing this though.


# Additional Project Management Things...

Closes #71 
Closes #72 